### PR TITLE
Add CuPL prompts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]
+.DS_Store
 
 # C extensions
 *.so

--- a/clip_benchmark/cli.py
+++ b/clip_benchmark/cli.py
@@ -75,7 +75,7 @@ def run(args):
             zeroshot_templates = dataset.templates_cupl
             assert (zeroshot_templates is not None), "Dataset does not support CuPL prompts"
         else:
-        	zeroshot_templates = dataset.templates if hasattr(dataset, "templates") else None
+            zeroshot_templates = dataset.templates if hasattr(dataset, "templates") else None
         if args.verbose:
             print(f"Zero-shot templates: {zeroshot_templates}")
         classnames = dataset.classes if hasattr(dataset, "classes") else None
@@ -89,7 +89,7 @@ def run(args):
             amp=args.amp,
             verbose=args.verbose,
             cupl = args.cupl
-            )
+        )
     elif args.task == "zeroshot_retrieval":
         metrics = zeroshot_retrieval.evaluate(
             model,

--- a/clip_benchmark/cli.py
+++ b/clip_benchmark/cli.py
@@ -32,9 +32,10 @@ def main():
     parser.add_argument('--language', default="en", type=str, help="language of classname and prompts to use for zeroshot classification.")
     parser.add_argument('--output', default="result.json", type=str, help="output file where to dump the metrics")
     parser.add_argument('--verbose', default=False, action="store_true", help="verbose mode")
+    parser.add_argument('--cupl', default=False, action="store_true", help="Use natural language prompt from CuPL paper")
     args = parser.parse_args()
     run(args)
-    
+
 def run(args):
     """Console script for clip_benchmark."""
     args.device = "cuda" if torch.cuda.is_available() else "cpu"
@@ -47,10 +48,10 @@ def run(args):
         model = model.to(args.device)
         tokenizer = open_clip.get_tokenizer(args.model)
         dataset = build_dataset(
-            dataset_name=args.dataset, 
-            root=args.dataset_root, 
-            transform=transform, 
-            split=args.split, 
+            dataset_name=args.dataset,
+            root=args.dataset_root,
+            transform=transform,
+            split=args.split,
             annotation_file=args.annotation_file,
             download=True,
             language=args.language,
@@ -63,55 +64,60 @@ def run(args):
             print(f"Dataset number of classes: {len(dataset.classes)}")
 
         dataloader = torch.utils.data.DataLoader(
-            dataset, batch_size=args.batch_size, 
-            shuffle=False, num_workers=args.num_workers, 
+            dataset, batch_size=args.batch_size,
+            shuffle=False, num_workers=args.num_workers,
             collate_fn=collate_fn
         )
 
 
     if args.task == "zeroshot_classification":
-        zeroshot_templates = dataset.templates if hasattr(dataset, "templates") else None
+        if args.cupl:
+            zeroshot_templates = dataset.templates_cupl
+            assert (zeroshot_templates is not None), "Dataset does not support CuPL prompts"
+        else:
+        	zeroshot_templates = dataset.templates if hasattr(dataset, "templates") else None
         if args.verbose:
             print(f"Zero-shot templates: {zeroshot_templates}")
         classnames = dataset.classes if hasattr(dataset, "classes") else None
         assert (zeroshot_templates is not None and classnames is not None), "Dataset does not support classification"
         metrics = zeroshot_classification.evaluate(
-            model, 
-            dataloader, 
-            tokenizer, 
-            classnames, zeroshot_templates, 
-            device=args.device, 
+            model,
+            dataloader,
+            tokenizer,
+            classnames, zeroshot_templates,
+            device=args.device,
             amp=args.amp,
             verbose=args.verbose,
-        )
+            cupl = args.cupl
+            )
     elif args.task == "zeroshot_retrieval":
         metrics = zeroshot_retrieval.evaluate(
-            model, 
-            dataloader, 
-            tokenizer, 
+            model,
+            dataloader,
+            tokenizer,
             recall_k_list=args.recall_k,
-            device=args.device, 
+            device=args.device,
             amp=args.amp
         )
     elif args.task == "linear_probe":
         # we also need the train split for linear probing.
         train_dataset = build_dataset(
-            dataset_name=args.dataset, 
-            root=args.dataset_root, 
-            transform=transform, 
-            split='train', 
+            dataset_name=args.dataset,
+            root=args.dataset_root,
+            transform=transform,
+            split='train',
             annotation_file=args.annotation_file,
             download=True,
         )
         train_dataloader = torch.utils.data.DataLoader(
-            train_dataset, batch_size=args.batch_size, 
-            shuffle=False, num_workers=args.num_workers, 
+            train_dataset, batch_size=args.batch_size,
+            shuffle=False, num_workers=args.num_workers,
             collate_fn=collate_fn, pin_memory=True,
         )
         metrics = linear_probe.evaluate(
             model,
-            train_dataloader, 
-            dataloader, 
+            train_dataloader,
+            dataloader,
             args.fewshot_k,
             args.batch_size,
             args.num_workers,
@@ -120,7 +126,7 @@ def run(args):
             (args.model + '-' + args.pretrained + '-' + args.dataset).replace('/', '_'),
             args.seed,
             args.feature_root,
-            device=args.device, 
+            device=args.device,
             amp=args.amp,
             verbose=args.verbose,
         )

--- a/clip_benchmark/metrics/zeroshot_classification.py
+++ b/clip_benchmark/metrics/zeroshot_classification.py
@@ -12,27 +12,27 @@ from tqdm import tqdm
 from sklearn.metrics import classification_report, balanced_accuracy_score
 
 
-def zero_shot_classifier(model, tokenizer, classnames, templates, device, amp=True):
+def zero_shot_classifier(model, tokenizer, classnames, templates, device, amp=True, cupl=False):
     """
     This function returns zero-shot vectors for each class in order
     to use it for zero-shot classification.
-    
+
 
     model:
         CLIP-like model with `encode_text`
-    
+
     tokenizer:
         text tokenizer, i.e. convert list of strings to torch.Tensor of integers
-    
+
     classnames: list of str
         name of classes
-    
+
     templates: list of str
         templates to use.
-    
+
     Returns
     -------
-    
+
     torch.Tensor of shape (N,C) where N is the number
     of templates, and C is the number of classes.
     """
@@ -40,7 +40,10 @@ def zero_shot_classifier(model, tokenizer, classnames, templates, device, amp=Tr
     with torch.no_grad(), autocast():
         zeroshot_weights = []
         for classname in tqdm(classnames):
-            texts = [template.format(c=classname) for template in templates]  # format with class
+            if cupl:
+                texts = templates[classname]
+            else:
+                texts = [template.format(c=classname) for template in templates]  # format with class
             texts = tokenizer(texts).to(device)  # tokenize
             class_embeddings = model.encode_text(texts)
             class_embedding = F.normalize(class_embeddings, dim=-1).mean(dim=0)
@@ -57,16 +60,16 @@ def accuracy(output, target, topk=(1,)):
     output: torch.Tensor
         shape (N, C) where N is the number of examples, C the number of classes.
         these are the logits.
-    
+
     target: torch.Tensor
         shape (N,) where N is the number of examples. Groundtruth class id of each example.
-    
+
     topk: tuple
         which topk to compute, e.g., topk=(1,5) will compute top-1 and top-5 accuracies
-    
+
     Returns
     -------
-    
+
     list of top-k accuracies in the same order as `topk`
     """
     pred = output.topk(max(topk), 1, True, True)[1].t()
@@ -81,12 +84,12 @@ def run_classification(model, classifier, dataloader, device, amp=True):
 
     model: torch.nn.Module
         CLIP-like model with `encode_image` and `encode_text`
-    
+
     classifier: torch.Tensor
         obtained from the function `zero_shot_classifier`
-    
-    dataloader: torch.utils.data.Dataloader 
-    
+
+    dataloader: torch.utils.data.Dataloader
+
     Returns
     -------
     (pred, true)  where
@@ -107,7 +110,7 @@ def run_classification(model, classifier, dataloader, device, amp=True):
                 image_features = model.encode_image(images)
                 image_features = F.normalize(image_features, dim=-1)
                 logits = 100. * image_features @ classifier
-            
+
             true.append(target.cpu())
             pred.append(logits.float().cpu())
 
@@ -127,17 +130,17 @@ def average_precision_per_class(scores, targets):
 
     scores: torch.Tensor
         logits, of shape (N,C) where N is the number of examples, C the number of classes
-    
+
     targets: torch.Tensor
         one-hot vectors of groundtruth targets (N, C), where N is the number of examples, C is the
         number of classes
-    
+
     Returns
     -------
 
-    torch.Tensor of shape (C,) of avereage precision for each class, where C is     
+    torch.Tensor of shape (C,) of avereage precision for each class, where C is
     the number of classes.
-    
+
     """
     ap = torch.zeros(scores.size(1))
     rg = torch.arange(1, scores.size(0) + 1).float()
@@ -156,7 +159,7 @@ def average_precision_per_class(scores, targets):
     return ap
 
 
-def evaluate(model, dataloader, tokenizer, classnames, templates, device, amp=True, verbose=False):
+def evaluate(model, dataloader, tokenizer, classnames, templates, device, amp=True, verbose=False, cupl=False):
     """
     Run zero-shot classification and evaluate the metrics
 
@@ -165,17 +168,17 @@ def evaluate(model, dataloader, tokenizer, classnames, templates, device, amp=Tr
 
     model: torch.nn.Module
         CLIP-like model with `encode_image` and `encode_text`
-    
+
     dataloader: torch.utils.data.Dataloader
 
     tokenizer: text tokenizer
 
     classnames: list of str
         class names
-    
+
     templates: list of str
         templates to use for zero-shot classification
-    
+
     device: cpu/cuda
 
     amp: whether to use automatic mixed precision
@@ -187,7 +190,7 @@ def evaluate(model, dataloader, tokenizer, classnames, templates, device, amp=Tr
 
     dict of classification metrics
     """
-    classifier = zero_shot_classifier(model, tokenizer, classnames, templates, device)
+    classifier = zero_shot_classifier(model, tokenizer, classnames, templates, device, cupl=cupl)
     logits, target = run_classification(model, classifier, dataloader, device, amp=amp)
     is_multilabel = (len(target.shape) == 2)
 
@@ -210,7 +213,7 @@ def evaluate(model, dataloader, tokenizer, classnames, templates, device, amp=Tr
             acc1, acc5 = accuracy(logits, target, topk=(1, 5))
         else:
             acc1, = accuracy(logits, target, topk=(1,))
-            acc5 = float("nan") 
+            acc5 = float("nan")
         mean_per_class_recall = balanced_accuracy_score(target, pred)
         if verbose:
             print(classification_report(target, pred, digits=3))


### PR DESCRIPTION
Added prompts from https://arxiv.org/abs/2209.03320. Add `--cupl` flag to include.

```
python clip_benchmark/cli.py --dataset=imagenet1k-unverified --datas
et_root /data/yfcc-tmp/data/imagenet --task=zeroshot_classification --pretrained=frozen_laion5b_s13b_b90k -
-model=xlm-roberta-large-ViT-H-14 --output=result.json --cupl --batch_size=64
```
Results: 
```
{"dataset": "imagenet1k-unverified", "model": "xlm-roberta-large-ViT-H-14", "pretrained": "frozen_laion5b_s
13b_b90k", "task": "zeroshot_classification", "metrics": {"acc1": 0.77524, "acc5": 0.95464, "mean_per_class
_recall": 0.77538}, "language": "en"}
```


While it helps for the OpenAI models, it does not lead to improvements for other LAION models right now but I can work on improving that. E.g., for the laion-2b ViT-H-14 its 78.04%.