### PR TITLE
Add CuPL prompts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]
+.DS_Store
 
 # C extensions
 *.so

--- a/clip_benchmark/cli.py
+++ b/clip_benchmark/cli.py
@@ -73,6 +73,8 @@ def run(args):
 
     if args.task == "zeroshot_classification":
         zeroshot_templates = dataset.templates if hasattr(dataset, "templates") else None
+        if args.cupl:
+            assert (zeroshot_templates is not None), "Dataset does not support CuPL prompts"        
         if args.verbose:
             print(f"Zero-shot templates: {zeroshot_templates}")
         classnames = dataset.classes if hasattr(dataset, "classes") else None
@@ -85,6 +87,7 @@ def run(args):
             device=args.device, 
             amp=args.amp,
             verbose=args.verbose,
+            cupl=args.cupl
         )
     elif args.task == "zeroshot_retrieval":
         metrics = zeroshot_retrieval.evaluate(

--- a/clip_benchmark/cli.py
+++ b/clip_benchmark/cli.py
@@ -33,6 +33,8 @@ def main():
     parser.add_argument('--output', default="result.json", type=str, help="output file where to dump the metrics")
     parser.add_argument('--verbose', default=False, action="store_true", help="verbose mode")
     parser.add_argument('--cupl', default=False, action="store_true", help="Use natural language prompt from CuPL paper")
+    parser.add_argument('--save_clf', default=None, type=str, help="optionally save the classification layer output by the text tower")
+    parser.add_argument('--load_clfs', nargs='+', default=[], type=str, help="optionally load and average mutliple layers output by text towers.")
     args = parser.parse_args()
     run(args)
     
@@ -87,7 +89,9 @@ def run(args):
             device=args.device, 
             amp=args.amp,
             verbose=args.verbose,
-            cupl=args.cupl
+            cupl=args.cupl,
+            save_clf=args.save_clf,
+            load_clfs=args.load_clfs,
         )
     elif args.task == "zeroshot_retrieval":
         metrics = zeroshot_retrieval.evaluate(

--- a/clip_benchmark/cli.py
+++ b/clip_benchmark/cli.py
@@ -32,6 +32,7 @@ def main():
     parser.add_argument('--language', default="en", type=str, help="language of classname and prompts to use for zeroshot classification.")
     parser.add_argument('--output', default="result.json", type=str, help="output file where to dump the metrics")
     parser.add_argument('--verbose', default=False, action="store_true", help="verbose mode")
+    parser.add_argument('--cupl', default=False, action="store_true", help="Use natural language prompt from CuPL paper")
     args = parser.parse_args()
     run(args)
     
@@ -54,6 +55,7 @@ def run(args):
             annotation_file=args.annotation_file,
             download=True,
             language=args.language,
+            cupl=args.cupl
         )
         collate_fn = get_dataset_collate_fn(args.dataset)
         if args.verbose:

--- a/clip_benchmark/datasets/builder.py
+++ b/clip_benchmark/datasets/builder.py
@@ -59,7 +59,7 @@ def build_dataset(dataset_name, root="root", transform=None, split="test", downl
 
     with open(os.path.join(current_folder, "cupl_prompts.json"), "r") as f:
         cupl_prompts = json.load(f)
-    templates_cupl = cupl_prompts
+    templates_cupl = None
 
     train = (split == "train")
     if dataset_name == "cifar10":
@@ -75,18 +75,19 @@ def build_dataset(dataset_name, root="root", transform=None, split="test", downl
         ds =  ImageNet(root=root, split="train" if train else "val", transform=transform, **kwargs)
         # use classnames from OpenAI
         ds.classes = classnames["imagenet1k"]
+        templates_cupl = cupl_prompts["imagenet1k"]
     elif dataset_name == "imagenet1k-unverified":
         split = "train" if train else "val"
         ds =  ImageFolder(root=os.path.join(root, split), transform=transform, **kwargs)
         # use classnames from OpenAI
         ds.classes = classnames["imagenet1k"]
-        templates_cupl["imagenet1k-unverified"] = templates_cupl["imagenet1k"]
+        templates_cupl = cupl_prompts["imagenet1k"]
     elif dataset_name == "imagenetv2":
         assert split == "test", f"Only test split available for {dataset_name}"
         os.makedirs(root, exist_ok=True)
         ds = imagenetv2.ImageNetV2Dataset(variant="matched-frequency", transform=transform, location=root)
         ds.classes = classnames["imagenet1k"]
-        templates_cupl["imagenetv2"] = templates_cupl["imagenet1k"]
+        templates_cupl = cupl_prompts["imagenet1k"]
     elif dataset_name == "imagenet_sketch":
         assert split == "test", f"Only test split available for {dataset_name}"
         # Downloadable from https://drive.google.com/open?id=1Mj0i5HBthqH1p_yeXzsg22gZduvgoNeA
@@ -104,7 +105,7 @@ def build_dataset(dataset_name, root="root", transform=None, split="test", downl
             call(f"mv sketch {root}", shell=True)
         ds = ImageFolder(root=root, transform=transform, **kwargs)
         ds.classes = classnames["imagenet1k"]
-        templates_cupl["imagenet_sketch"] = templates_cupl["imagenet1k"]
+        templates_cupl = cupl_prompts["imagenet1k"]
     elif dataset_name == "imagenet-a":
         assert split == "test", f"Only test split available for {dataset_name}"
         # Downloadable from https://people.eecs.berkeley.edu/~hendrycks/imagenet-a.tar

--- a/clip_benchmark/datasets/builder.py
+++ b/clip_benchmark/datasets/builder.py
@@ -15,7 +15,7 @@ from . import voc2007, flickr, caltech101, imagenetv2, objectnet
 from torch.utils.data import default_collate
 from PIL import Image
 
-def build_dataset(dataset_name, root="root", transform=None, split="test", download=True, annotation_file=None, language="en", **kwargs):
+def build_dataset(dataset_name, root="root", transform=None, split="test", download=True, annotation_file=None, language="en", cupl=False, **kwargs):
     """
     Main function to use in order to build a dataset instance,
 
@@ -57,6 +57,10 @@ def build_dataset(dataset_name, root="root", transform=None, split="test", downl
         name = dataset_name
     templates = zeroshot_classification_templates.get(name, DEFAULT_ZEROSHOT_CLASSIFICATION_TEMPLATES)
 
+    with open(os.path.join(current_folder, "cupl_prompts.json"), "r") as f:
+        cupl_prompts = json.load(f)
+    templates_cupl = cupl_prompts
+
     train = (split == "train")
     if dataset_name == "cifar10":
         ds = CIFAR10(root=root, train=train, transform=transform, download=download, **kwargs)
@@ -76,11 +80,13 @@ def build_dataset(dataset_name, root="root", transform=None, split="test", downl
         ds =  ImageFolder(root=os.path.join(root, split), transform=transform, **kwargs)
         # use classnames from OpenAI
         ds.classes = classnames["imagenet1k"]
+        templates_cupl["imagenet1k-unverified"] = templates_cupl["imagenet1k"]
     elif dataset_name == "imagenetv2":
         assert split == "test", f"Only test split available for {dataset_name}"
         os.makedirs(root, exist_ok=True)
         ds = imagenetv2.ImageNetV2Dataset(variant="matched-frequency", transform=transform, location=root)
         ds.classes = classnames["imagenet1k"]
+        templates_cupl["imagenetv2"] = templates_cupl["imagenet1k"]
     elif dataset_name == "imagenet_sketch":
         assert split == "test", f"Only test split available for {dataset_name}"
         # Downloadable from https://drive.google.com/open?id=1Mj0i5HBthqH1p_yeXzsg22gZduvgoNeA
@@ -98,6 +104,7 @@ def build_dataset(dataset_name, root="root", transform=None, split="test", downl
             call(f"mv sketch {root}", shell=True)
         ds = ImageFolder(root=root, transform=transform, **kwargs)
         ds.classes = classnames["imagenet1k"]
+        templates_cupl["imagenet_sketch"] = templates_cupl["imagenet1k"]
     elif dataset_name == "imagenet-a":
         assert split == "test", f"Only test split available for {dataset_name}"
         # Downloadable from https://people.eecs.berkeley.edu/~hendrycks/imagenet-a.tar
@@ -298,7 +305,10 @@ def build_dataset(dataset_name, root="root", transform=None, split="test", downl
     else:
         raise ValueError(f"Unsupported dataset: {dataset_name}.")
 
-    ds.templates = templates
+    if cupl:
+        ds.templates = templates_cupl
+    else:
+        ds.templates = templates
 
     return ds
 

--- a/sync_hyak.sh
+++ b/sync_hyak.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-rsync -avz \
-  --exclude .git/ \
-   ../CLIP_benchmark spratt3@klone.hyak.uw.edu:/gscratch/raivn/spratt

--- a/sync_hyak.sh
+++ b/sync_hyak.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+rsync -avz \
+  --exclude .git/ \
+   ../CLIP_benchmark spratt3@klone.hyak.uw.edu:/gscratch/raivn/spratt

--- a/tests/test_clip_benchmark.py
+++ b/tests/test_clip_benchmark.py
@@ -24,6 +24,8 @@ class base_args:
     skip_load=False
     language="en"
     cupl=False
+    save_clf=None
+    load_clfs=[]
 
 def test_base():
     run(base_args)

--- a/tests/test_clip_benchmark.py
+++ b/tests/test_clip_benchmark.py
@@ -23,6 +23,7 @@ class base_args:
     seed=0
     skip_load=False
     language="en"
+    cupl=False
 
 def test_base():
     run(base_args)


### PR DESCRIPTION
Added prompts from https://arxiv.org/abs/2209.03320. Add `--cupl` flag to include.

```
python clip_benchmark/cli.py --dataset=imagenet1k-unverified --task=zeroshot_classification --pretrained=frozen_laion5b_s13b_b90k --model=xlm-roberta-large-ViT-H-14 --output=result.json --cupl --batch_size=64
```
Results: 
```
{"dataset": "imagenet1k-unverified", "model": "xlm-roberta-large-ViT-H-14", "pretrained": "frozen_laion5b_s
13b_b90k", "task": "zeroshot_classification", "metrics": {"acc1": 0.77524, "acc5": 0.95464, "mean_per_class
_recall": 0.77538}, "language": "en"}
```

While it helps for the OpenAI models, it does not lead to improvements for other LAION models right now but I can work on improving that. E.g., for the laion-2b ViT-H-14 its 78.04%.