### PR TITLE
update run.sh script (output file and annotation file)

### DIFF
--- a/benchmark/run.sh
+++ b/benchmark/run.sh
@@ -27,7 +27,7 @@ for ds in $DATASETS;do
        echo "$ds_name"
        echo "$LANGUAGE"
        echo $TASK
-       $RUN --dataset=$ds --language=$LANGUAGE --annotation_file=$ROOT/$ds/captions.txt --dataset_root $ROOT/$ds --task=$TASK --pretrained=$pretrained --model=$arch --output="${ds_name}_${name}_${arch}_${LANGUAGE}.json"  --batch_size=$BS --num_workers=$WORKERS
+       $RUN --dataset=$ds --language=$LANGUAGE --dataset_root $ROOT/$ds --task=$TASK --pretrained=$pretrained --model=$arch --output="${ds_name}_${pretrained}_${arch}_${LANGUAGE}.json"  --batch_size=$BS --num_workers=$WORKERS
     done
 done
 python build_csv.py


### PR DESCRIPTION

- Providing annotation file for retrieval not needed anymore (it is downloaded automatically)
-  Use pretrained model name in the output filename.

small update but we will anyway switch to a Python script for running the benchmark
