### PR TITLE
Added wds/voc2007_multilabel

### DIFF
--- a/benchmark/webdatasets.txt
+++ b/benchmark/webdatasets.txt
@@ -10,6 +10,7 @@ wds/imagenet-o
 wds/objectnet
 wds/fer2013
 wds/voc2007
+wds/voc2007_multilabel
 wds/sun397
 wds/cars
 wds/fgvc_aircraft

--- a/clip_benchmark/datasets/builder.py
+++ b/clip_benchmark/datasets/builder.py
@@ -623,8 +623,9 @@ def build_wds_dataset(dataset_name, transform, split="test", data_dir="root", ca
         )
         dataset.classes = dataset.templates = None
     else:
+        label_type = "npy" if dataset_type == "multilabel" else "cls" # Special case for multilabel
         dataset = (dataset
-            .to_tuple(["webp", "png", "jpg", "jpeg"], "cls")
+            .to_tuple(["webp", "png", "jpg", "jpeg"], label_type)
             .map_tuple(transform, None)
         )
         # Get class names if present


### PR DESCRIPTION
Finishing off support for all datasets currently supported through the original interface:
* Multilabel datasets can be converted to and loaded from webdataset
* Converted and uploaded voc2007_multilabel to HF
* Accuracies match within 0.0001

You can test the new dataset with: (replacing model with whatever you like)
```sh
clip_benchmark eval --dataset wds/voc2007_multilabel --dataset_root "https://huggingface.co/datasets/clip-benchmark/wds_voc2007_multilabel/tree/main" --model "ViT-B-32" --pretrained "openai" --output results_voc2007_multilabel.json
```