### PR TITLE
Fix silent webdataset error-handling

### DIFF
--- a/clip_benchmark/datasets/builder.py
+++ b/clip_benchmark/datasets/builder.py
@@ -594,11 +594,7 @@ def build_wds_dataset(dataset_name, transform, split="test", data_dir="root", ca
         metadata_dir = tardata_dir = data_dir
     # Get number of shards
     nshards_fname = os.path.join(metadata_dir, split, "nshards.txt")
-    try:
-        nshards = int(read_txt(nshards_fname))
-    except FileNotFoundError:
-        print("WARNING: nshards.txt not found, using nshards=1")
-        nshards = 1
+    nshards = int(read_txt(nshards_fname)) # Do not catch FileNotFound, nshards.txt should be mandatory
     # Get dataset type (classification or retrieval)
     type_fname = os.path.join(metadata_dir, "dataset_type.txt")
     try:


### PR DESCRIPTION
Originally, if nshards.txt didn't exist, I would print a warning and assume nshards = 1. This can cause results to be wrong if streaming from HF due to network issues, and is easy to go undetected. I removed this behavior, so that network issues will raise an exception instead of evaluating on one shard only.