### PR TITLE
Fix crash when using `--distributed`

### DIFF
--- a/clip_benchmark/datasets/builder.py
+++ b/clip_benchmark/datasets/builder.py
@@ -759,7 +759,7 @@ def build_wds_dataset(dataset_name, transform, split="test", data_dir="root", ca
     if not cache_dir or not isinstance(cache_dir, str):
         cache_dir = None
     dataset = (
-        wds.WebDataset(filepattern, cache_dir=cache_dir)
+        wds.WebDataset(filepattern, cache_dir=cache_dir, nodesplitter=lambda src: src)
         .decode(wds.autodecode.ImageHandler("pil", extensions=["webp", "png", "jpg", "jpeg"]))
     )
     # Load based on classification or retrieval task


### PR DESCRIPTION
The distributed mode (evaluation in parallel) uses a world size greater than 1, by definition. However, `WebDataset` default `nodesplitter` supposes that the dataset will be sharded throughout multiple nodes if using the distributed mode, which is not the case here (each node gets a different dataset). `WebDataset` default `nodesplitter` uses a sanity check for this, and the program crashes. This change substitutes the default `nodesplitter` function with an identity function (the same functionality as before) but without this assertion.