### PR TITLE
Fix docstring typo of zero_shot_classifier

### DIFF
--- a/clip_benchmark/metrics/zeroshot_classification.py
+++ b/clip_benchmark/metrics/zeroshot_classification.py
@@ -34,8 +34,8 @@ def zero_shot_classifier(model, tokenizer, classnames, templates, device, amp=Tr
     Returns
     -------
     
-    torch.Tensor of shape (N,C) where N is the number
-    of templates, and C is the number of classes.
+    torch.Tensor of shape (D,C) where D is the projection
+    dimension, and C is the number of classes.
     """
     with torch.no_grad(), torch.autocast(device, enabled=amp):
         zeroshot_weights = []


### PR DESCRIPTION
Hi, I think there is a typo in the docstring of `zero_shot_classifier`. The output is the average embeddings of all the templates. So the shape of `zeroshot_weights` should be determined by the projection output size `D` and the number of classes `C`.